### PR TITLE
WIP: Update query-executor service to generate HTML response via Spring MVC

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -76,6 +76,10 @@
             <artifactId>spring-context</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-webmvc</artifactId>
+        </dependency>
+        <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>

--- a/api/src/main/java/datawave/microservice/query/result/ExecutorMetricsResponse.java
+++ b/api/src/main/java/datawave/microservice/query/result/ExecutorMetricsResponse.java
@@ -5,6 +5,7 @@ import datawave.core.common.result.ConnectionPool;
 import datawave.webservice.HtmlProvider;
 import datawave.webservice.result.BaseResponse;
 import org.apache.commons.lang.StringEscapeUtils;
+import org.springframework.web.servlet.ModelAndView;
 
 import javax.xml.bind.annotation.XmlAccessOrder;
 import javax.xml.bind.annotation.XmlAccessType;
@@ -48,6 +49,20 @@ public class ExecutorMetricsResponse extends BaseResponse implements HtmlProvide
     
     @XmlElement(name = "queryToTask")
     private Map<String,Collection<QueryTaskDescription>> queryToTask;
+    
+    public ModelAndView createModelAndView() {
+        ModelAndView mav = new ModelAndView();
+        
+        mav.setViewName("executormetrics");
+        
+        mav.addObject("title", getTitle());
+        mav.addObject("threadPoolStatus", threadPoolStatus);
+        mav.addObject("queryToTask", getQueryToTask());
+        mav.addObject("queryMetricsUrlPrefix", queryMetricsUrlPrefix);
+        mav.addObject("connectionPools", connectionPools);
+        
+        return mav;
+    }
     
     @Override
     public String getTitle() {

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -263,6 +263,10 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-thymeleaf</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.kafka</groupId>
             <artifactId>spring-kafka</artifactId>
         </dependency>

--- a/service/src/main/java/datawave/microservice/query/executor/QueryExecutorController.java
+++ b/service/src/main/java/datawave/microservice/query/executor/QueryExecutorController.java
@@ -70,7 +70,7 @@ public class QueryExecutorController {
     @Timed(name = "dw.query.executor.getExecutorThreadPoolMetrics", absolute = true)
     @Secured({"Administrator", "JBossAdministrator", "InternalUser"})
     @RequestMapping(path = "ThreadPool/stats", method = {RequestMethod.GET},
-                    produces = {"application/xml", "text/xml", "application/json", "text/yaml", "text/x-yaml", "application/x-yaml", "text/html"})
+                    produces = {"application/xml", "text/xml", "application/json", "text/yaml", "text/x-yaml", "application/x-yaml"})
     public ExecutorMetricsResponse getExecutorThreadPoolMetrics() {
         ExecutorMetricsResponse response = new ExecutorMetricsResponse();
         response.setTitle("Executor Thread Pool Metrics for " + queryExecutor.getExecutorProperties().getPool());
@@ -95,7 +95,7 @@ public class QueryExecutorController {
     @Timed(name = "dw.query.executor.getExecutorQueries", absolute = true)
     @Secured({"Administrator", "JBossAdministrator", "InternalUser"})
     @RequestMapping(path = "queries", method = {RequestMethod.GET},
-                    produces = {"application/xml", "text/xml", "application/json", "text/yaml", "text/x-yaml", "application/x-yaml", "text/html"})
+                    produces = {"application/xml", "text/xml", "application/json", "text/yaml", "text/x-yaml", "application/x-yaml"})
     public ExecutorMetricsResponse getExecutorQueries() {
         ExecutorMetricsResponse response = new ExecutorMetricsResponse();
         response.setTitle("Executor Queries for " + queryExecutor.getExecutorProperties().getPool());

--- a/service/src/main/java/datawave/microservice/query/executor/QueryExecutorWebController.java
+++ b/service/src/main/java/datawave/microservice/query/executor/QueryExecutorWebController.java
@@ -1,0 +1,132 @@
+package datawave.microservice.query.executor;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.stream.Collectors;
+
+import org.springframework.http.MediaType;
+import org.springframework.security.access.annotation.Secured;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.servlet.ModelAndView;
+
+import com.codahale.metrics.annotation.Timed;
+import com.google.common.collect.Multimap;
+
+import datawave.microservice.query.executor.action.ExecutorTask;
+import datawave.microservice.query.result.ExecutorMetricsResponse;
+import datawave.microservice.query.result.QueryTaskDescription;
+import io.swagger.v3.oas.annotations.ExternalDocumentation;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "Query Executor Controller /v1", description = "DataWave Query Executor Operations",
+                externalDocs = @ExternalDocumentation(description = "Query Executor Service Documentation",
+                                url = "https://github.com/NationalSecurityAgency/datawave-query-executor-service"))
+@Controller
+@RequestMapping(path = "/v1", produces = {MediaType.TEXT_HTML_VALUE})
+public class QueryExecutorWebController {
+    
+    private final QueryExecutor queryExecutor;
+    
+    public QueryExecutorWebController(QueryExecutor queryExecutor) {
+        this.queryExecutor = queryExecutor;
+    }
+    
+    /**
+     * <strong>JBossAdministrator or Administrator credentials required.</strong> Returns metrics for the Executor thread pool
+     *
+     * @return an ExecutorMetricsResponse
+     * @RequestHeader X-ProxiedEntitiesChain use when proxying request for user
+     * @RequestHeader X-ProxiedIssuersChain required when using X-ProxiedEntitiesChain, specify one issuer DN per subject DN listed in X-ProxiedEntitiesChain
+     * @HTTP 200 success
+     * @HTTP 500 internal server error
+     */
+    @Operation(summary = "Returns metrics for the Executor thread pool.")
+    @Timed(name = "dw.query.executor.getExecutorThreadPoolMetrics", absolute = true)
+    @Secured({"Administrator", "JBossAdministrator", "InternalUser"})
+    @RequestMapping(path = "ThreadPool/stats", method = {RequestMethod.GET}, produces = {"text/html"})
+    public ModelAndView getExecutorThreadPoolMetricsWebpage() {
+        ExecutorMetricsResponse response = new ExecutorMetricsResponse();
+        response.setTitle("Executor Thread Pool Metrics for " + queryExecutor.getExecutorProperties().getPool());
+        response.setPool(queryExecutor.getExecutorProperties().getPool());
+        response.setQueryMetricsUrlPrefix(queryExecutor.getExecutorProperties().getQueryMetricsUrlPrefix());
+        response.setConnectionPools(null);
+        response.setThreadPoolStatus(getThreadPoolStatus(queryExecutor.getThreadPoolExecutor()));
+        response.setQueryToTask(null);
+        
+        return response.createModelAndView();
+    }
+    
+    /**
+     * <strong>JBossAdministrator or Administrator credentials required.</strong> Returns queries being serviced
+     *
+     * @return an ExecutorMetricsResponse
+     * @RequestHeader X-ProxiedEntitiesChain use when proxying request for user
+     * @RequestHeader X-ProxiedIssuersChain required when using X-ProxiedEntitiesChain, specify one issuer DN per subject DN listed in X-ProxiedEntitiesChain
+     * @HTTP 200 success
+     * @HTTP 500 internal server error
+     */
+    @Operation(summary = "Returns queries being serviced.")
+    @Timed(name = "dw.query.executor.getExecutorQueries", absolute = true)
+    @Secured({"Administrator", "JBossAdministrator", "InternalUser"})
+    @RequestMapping(path = "queries", method = {RequestMethod.GET}, produces = {"text/html"})
+    public ModelAndView getExecutorQueriesWebpage() {
+        ExecutorMetricsResponse response = new ExecutorMetricsResponse();
+        response.setTitle("Executor Queries for " + queryExecutor.getExecutorProperties().getPool());
+        response.setPool(queryExecutor.getExecutorProperties().getPool());
+        response.setQueryMetricsUrlPrefix(queryExecutor.getExecutorProperties().getQueryMetricsUrlPrefix());
+        response.setConnectionPools(null);
+        response.setThreadPoolStatus(null);
+        response.setQueryToTask(getQueryToTask(queryExecutor.getQueryToTasks()));
+        
+        return response.createModelAndView();
+    }
+    
+    private Map<String,Collection<QueryTaskDescription>> getQueryToTask(Multimap<String,ExecutorTask> queryTasks) {
+        Map<String,Collection<QueryTaskDescription>> queryToTask = new HashMap<>();
+        for (Map.Entry<String,Collection<ExecutorTask>> entry : queryTasks.asMap().entrySet()) {
+            queryToTask.put(entry.getKey(), entry.getValue().stream().map(r -> new QueryTaskDescription(String.valueOf(r.getTaskKey().getTaskId()),
+                            r.getTask().getAction().name(), r.getTaskKey().getQueryLogic(), getStatus(r))).collect(Collectors.toList()));
+        }
+        return queryToTask;
+    }
+    
+    private Map<String,String> getThreadPoolStatus(ThreadPoolExecutor threadPoolExecutor) {
+        Map<String,String> status = new HashMap<>();
+        status.put("status", getStatus(threadPoolExecutor));
+        status.put("pool size", String.valueOf(threadPoolExecutor.getPoolSize()));
+        status.put("active threads", String.valueOf(threadPoolExecutor.getActiveCount()));
+        status.put("queued tasks", String.valueOf(threadPoolExecutor.getQueue().size()));
+        status.put("completed tasks", String.valueOf(threadPoolExecutor.getCompletedTaskCount()));
+        return status;
+    }
+    
+    private String getStatus(ThreadPoolExecutor threadPoolExecutor) {
+        if (threadPoolExecutor.isShutdown())
+            return "Shutdown";
+        else if (threadPoolExecutor.isTerminated())
+            return "Terminated";
+        else if (threadPoolExecutor.isTerminating())
+            return "Terminating";
+        else
+            return "Running";
+    }
+    
+    private String getStatus(ExecutorTask task) {
+        if (task.isTaskComplete()) {
+            return "Complete";
+        } else if (task.isTaskFailed()) {
+            return "Failed";
+        } else if (task.isInterrupted()) {
+            return "Interrupted";
+        } else if (task.isRunning()) {
+            return "Running";
+        } else {
+            return "Queued";
+        }
+    }
+}

--- a/service/src/main/resources/templates/executormetrics.html
+++ b/service/src/main/resources/templates/executormetrics.html
@@ -1,0 +1,89 @@
+<html xmlns:th="http:/>/www.thymeleaf.org">
+<!--/*
+    The HTML page for ExecutorMetricsResponse
+*/-->
+<head>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8">
+    <title th:text="'DATAWAVE - ' + ${title}"></title>
+    <link rel="stylesheet" type="text/css" href="/executor/css/screen.css" media="screen">
+</head>
+<body>
+    <style>
+        table.threadPool td, table.threadPool th {
+            border-collapse: collapse;
+            border: 1px black solid;
+            empty-cells: hide;
+        }
+        
+        table.queryTasks td, table.queryTasks th {
+            border-collapse: collapse;
+            border: 1px black solid;
+            word-wrap: break-word;
+            empty-cells: hide;
+        }
+        
+        table.connectionPools td, table.connectionPools th {
+            border-collapse: collapse;
+            border: 1px black solid;
+            empty-cells: hide;
+        }
+        
+        table.connectionRequests td, table.connectionRequests th {
+            border-collapse: collapse;
+            border: 1px black solid;
+            word-wrap: break-word;
+            empty-cells: hide;
+        }
+    </style>
+
+    <h1 th:text="${title}"></h1>
+
+    <div th:if="${threadPoolStatus != null}">
+        <br> <!--/* TODO only add if hasSection */-->
+        <h2>Thread Pool</h2>
+        <br>
+        <table class="threadPool">
+            <tr>
+                <th>Property</th>
+                <th>Value</th>
+            </tr>
+            <tr th:each="elt : ${threadPoolStatus}">
+                <td th:text="${elt.key}"></td>
+                <td th:text="${elt.value}"></td>
+            </tr>
+        </table>
+    </div>
+
+    <div th:if = "${queryToTask != null}">
+        <br> <!--/* TODO only add if hasSection */-->
+        <h2>Query Tasks</h2>
+        <table class="queryTasks">
+            <tr>
+                <th>Query</th>
+                <th># Tasks</th>
+                <th>Task Id</th>
+                <th>Method</th>
+                <th>State</th>
+            </tr>
+            <span th:each="entry : ${queryToTask.entrySet()}">
+                <tr th:each="task,iter : ${entry.getValue()}">
+                    <td th:if = "${iter.index} == 0" th:class="(${queryMetricsUrlPrefix} != null and ${!queryMetricsUrlPrefix.isEmpty()}) ? 'allBoarders' : ''">
+                        <a th:if = "${queryMetricsUrlPrefix} != null and ${!queryMetricsUrlPrefix.isEmpty()}" th:text="${entry.getKey()}" th:href="${queryMetricsUrlPrefix} + ${entry.getKey()} + '/'"></a>
+                        <span th:unless = "${queryMetricsUrlPrefix} != null and ${!queryMetricsUrlPrefix.isEmpty()}" th:text="${entry.getKey()}"></span>
+                    </td>
+                    <td th:unless = "${iter.index} == 0"></td>
+                    <td th:if = "${iter.index} == 0" th:text="${entry.getValue().size()}"></td>
+                    <td th:unless = "${iter.index} == 0"></td>
+                    <td th:text="${task.getTaskId()}"></td>
+                    <td th:text="${task.getMethod()}"></td>
+                    <td th:text="${task.getState()}"></td>
+                </tr>
+            </span>
+        </table>
+    </div>
+    
+    <div th:if = "${connectionPools != null}">
+        <!--/* TODO... See ExecutorMetricsResponse */-->
+    </div>
+</body>
+</html>


### PR DESCRIPTION
For [DW#1666](https://github.com/NationalSecurityAgency/datawave/issues/1666).

Changes:
- WIP: ExecutorMetricsResponse to use Spring MVC instead of HtmlProvider
- spring-webmvc dependency to api/pom.xml so ModelAndView can be used in api/
- thymeleaf dependency to service/pom.xml